### PR TITLE
docs: fix "Comming" typo and remove duplicate checkpoint validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,9 +206,9 @@ Download the pretrained models before generating videos. Detailed instructions a
 |HunyuanVideo-1.5-480P-I2V-step-distill |[480P-I2V-step-distill](https://huggingface.co/tencent/HunyuanVideo-1.5/tree/main/transformer/480p_i2v_step_distilled) |
 |HunyuanVideo-1.5-720P-T2V|[720P-T2V](https://huggingface.co/tencent/HunyuanVideo-1.5/tree/main/transformer/720p_t2v) |
 |HunyuanVideo-1.5-720P-I2V |[720P-I2V](https://huggingface.co/tencent/HunyuanVideo-1.5/tree/main/transformer/720p_i2v) |
-|HunyuanVideo-1.5-720P-T2V-cfg-distill| Comming soon |
+|HunyuanVideo-1.5-720P-T2V-cfg-distill| Coming soon |
 |HunyuanVideo-1.5-720P-I2V-cfg-distill |[720P-I2V-cfg-distill](https://huggingface.co/tencent/HunyuanVideo-1.5/tree/main/transformer/720p_i2v_distilled) |
-|HunyuanVideo-1.5-720P-T2V-sparse-cfg-distill| Comming soon |
+|HunyuanVideo-1.5-720P-T2V-sparse-cfg-distill| Coming soon |
 |HunyuanVideo-1.5-720P-I2V-sparse-cfg-distill |[720P-I2V-sparse-cfg-distill](https://huggingface.co/tencent/HunyuanVideo-1.5/tree/main/transformer/720p_i2v_distilled_sparse) |
 |HunyuanVideo-1.5-720P-sr-step-distill |[720P-sr](https://huggingface.co/tencent/HunyuanVideo-1.5/tree/main/transformer/720p_sr_distilled) |
 |HunyuanVideo-1.5-1080P-sr-step-distill |[1080P-sr](https://huggingface.co/tencent/HunyuanVideo-1.5/tree/main/transformer/1080p_sr_distilled) |

--- a/README_CN.md
+++ b/README_CN.md
@@ -202,9 +202,9 @@ pip install -i https://mirrors.tencent.com/pypi/simple/ --upgrade tencentcloud-s
 |HunyuanVideo-1.5-480P-I2V-step-distill |[480P-I2V-step-distill](https://huggingface.co/tencent/HunyuanVideo-1.5/tree/main/transformer/480p_i2v_step_distilled) |
 |HunyuanVideo-1.5-720P-T2V|[720P-T2V](https://huggingface.co/tencent/HunyuanVideo-1.5/tree/main/transformer/720p_t2v) |
 |HunyuanVideo-1.5-720P-I2V |[720P-I2V](https://huggingface.co/tencent/HunyuanVideo-1.5/tree/main/transformer/720p_i2v) |
-|HunyuanVideo-1.5-720P-T2V-cfg-distill| Comming soon |
+|HunyuanVideo-1.5-720P-T2V-cfg-distill| Coming soon |
 |HunyuanVideo-1.5-720P-I2V-cfg-distill |[720P-I2V-cfg-distill](https://huggingface.co/tencent/HunyuanVideo-1.5/tree/main/transformer/720p_i2v_distilled) |
-|HunyuanVideo-1.5-720P-T2V-sparse-cfg-distill| Comming soon |
+|HunyuanVideo-1.5-720P-T2V-sparse-cfg-distill| Coming soon |
 |HunyuanVideo-1.5-720P-I2V-sparse-cfg-distill |[720P-I2V-sparse-cfg-distill](https://huggingface.co/tencent/HunyuanVideo-1.5/tree/main/transformer/720p_i2v_distilled_sparse) |
 |HunyuanVideo-1.5-720P-sr-step-distill |[720P-sr](https://huggingface.co/tencent/HunyuanVideo-1.5/tree/main/transformer/720p_sr_distilled) |
 |HunyuanVideo-1.5-1080P-sr-step-distill |[1080P-sr](https://huggingface.co/tencent/HunyuanVideo-1.5/tree/main/transformer/1080p_sr_distilled) |

--- a/generate.py
+++ b/generate.py
@@ -94,13 +94,10 @@ def str_to_bool(value):
     raise argparse.ArgumentTypeError(f"Boolean value expected, got: {value}")
 
 def load_checkpoint_to_transformer(pipe, checkpoint_path):
-    
+    # Basic validation to avoid confusing checkpoint errors
     if not os.path.exists(checkpoint_path):
         raise ValueError(f"Checkpoint path does not exist: {checkpoint_path}")
-    
-    if not os.path.exists(checkpoint_path):
-        raise ValueError(f"Transformer checkpoint directory not found: {checkpoint_path}")
-    
+
     rank0_log(f"Loading checkpoint from {checkpoint_path}", "INFO")
     
     try:

--- a/generate.py
+++ b/generate.py
@@ -94,10 +94,8 @@ def str_to_bool(value):
     raise argparse.ArgumentTypeError(f"Boolean value expected, got: {value}")
 
 def load_checkpoint_to_transformer(pipe, checkpoint_path):
-    # Basic validation to avoid confusing checkpoint errors
     if not os.path.exists(checkpoint_path):
         raise ValueError(f"Checkpoint path does not exist: {checkpoint_path}")
-
     rank0_log(f"Loading checkpoint from {checkpoint_path}", "INFO")
     
     try:


### PR DESCRIPTION
Fix typo "Comming" → "Coming" in README.md and README_CN.md (Model Cards table).

Remove duplicate os.path.exists(checkpoint_path) check in load_checkpoint_to_transformer() (generate.py). No logic change.