### PR TITLE
feat: add MiniMax Cloud API as alternative prompt rewrite provider (M3 default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,14 +227,25 @@ For users seeking to optimize prompts for other large models, it is recommended 
 ### Inference with Source Code
 
 
-For prompt rewriting, we recommend using Gemini or models deployed via vLLM. This codebase currently only supports models compatible with the vLLM API. If you wish to use Gemini, you will need to implement your own interface calls.
+For prompt rewriting, we recommend using Gemini or models deployed via vLLM. This codebase supports models compatible with the vLLM API, as well as [MiniMax](https://www.minimaxi.com/) Cloud API as an alternative cloud-hosted provider. If you wish to use Gemini, you will need to implement your own interface calls.
 
 For models with a vLLM API, note that T2V (text-to-video) and I2V (image-to-video) have different recommended models and environment variables:
 
 - T2V: use [Qwen3-235B-A22B-Thinking-2507](https://huggingface.co/Qwen/Qwen3-235B-A22B-Thinking-2507), configure `T2V_REWRITE_BASE_URL` and `T2V_REWRITE_MODEL_NAME`
 - I2V: use [Qwen3-VL-235B-A22B-Instruct](https://huggingface.co/Qwen/Qwen3-VL-235B-A22B-Instruct), configure `I2V_REWRITE_BASE_URL` and `I2V_REWRITE_MODEL_NAME`
 
-> You may set the above model names to any other vLLM-compatible models you have deployed (including HuggingFace models).  
+Alternatively, you can use **MiniMax Cloud API** for T2V prompt rewriting without deploying your own vLLM server:
+
+```bash
+export REWRITE_PROVIDER=minimax
+export MINIMAX_API_KEY="your_minimax_api_key"
+# Optionally override the model (default: MiniMax-M2.7):
+# export T2V_REWRITE_MODEL_NAME="MiniMax-M2.5-highspeed"
+```
+
+Available MiniMax models: `MiniMax-M2.7` (latest, recommended), `MiniMax-M2.5`, `MiniMax-M2.5-highspeed` (204K context). Get your API key at [MiniMax Platform](https://platform.minimaxi.com/).
+
+> You may set the above model names to any other vLLM-compatible models you have deployed (including HuggingFace models).
 > Rewriting is enabled by default (`--rewrite` defaults to `true`); to disable it explicitly, use `--rewrite false` or `--rewrite 0`. If no vLLM endpoint is configured, the pipeline runs without remote rewriting.
 
 Example: Generate a video (works for both T2V and I2V; set `IMAGE_PATH=none` for T2V or provide an image path for I2V)

--- a/README_CN.md
+++ b/README_CN.md
@@ -226,12 +226,23 @@ pip install -i https://mirrors.tencent.com/pypi/simple/ --upgrade tencentcloud-s
 ### 使用源代码推理
 
 
-对于提示词重写，我们推荐使用 Gemini 或通过 vLLM 部署的大模型。当前代码库仅支持兼容 vLLM 接口的模型，如果您希望使用 Gemini，需自行实现相关接口调用。
+对于提示词重写，我们推荐使用 Gemini 或通过 vLLM 部署的大模型。当前代码库支持兼容 vLLM 接口的模型，同时也支持 [MiniMax](https://www.minimaxi.com/) 云端 API 作为替代方案。如果您希望使用 Gemini，需自行实现相关接口调用。
 
 对于 vLLM 接口的模型，需要注意 T2V 和 I2V 推荐使用不同的模型和环境变量：
 
 - 文生视频（T2V）：推荐使用 [Qwen3-235B-A22B-Thinking-2507](https://huggingface.co/Qwen/Qwen3-235B-A22B-Thinking-2507)，并配置 `T2V_REWRITE_BASE_URL` 与 `T2V_REWRITE_MODEL_NAME`
 - 图生视频（I2V）：推荐使用 [Qwen3-VL-235B-A22B-Instruct](https://huggingface.co/Qwen/Qwen3-VL-235B-A22B-Instruct)，并配置 `I2V_REWRITE_BASE_URL` 与 `I2V_REWRITE_MODEL_NAME`
+
+您也可以使用 **MiniMax 云端 API** 进行 T2V 提示词重写，无需自行部署 vLLM 服务：
+
+```bash
+export REWRITE_PROVIDER=minimax
+export MINIMAX_API_KEY="your_minimax_api_key"
+# 可选：指定模型（默认为 MiniMax-M2.7）：
+# export T2V_REWRITE_MODEL_NAME="MiniMax-M2.5-highspeed"
+```
+
+可用的 MiniMax 模型：`MiniMax-M2.7`（最新，推荐）、`MiniMax-M2.5`、`MiniMax-M2.5-highspeed`（204K 上下文）。请在 [MiniMax 开放平台](https://platform.minimaxi.com/) 获取 API Key。
 
 > 你也可以将上述模型名替换为任何你已部署、与 vLLM 兼容的模型（包括 HuggingFace 等模型）。
 >

--- a/hyvideo/utils/rewrite/clients.py
+++ b/hyvideo/utils/rewrite/clients.py
@@ -81,6 +81,62 @@ class DeepSeekClient(object):
 
         return content, reasoning_content
 
+class MiniMaxClient(object):
+    """
+    Client for MiniMax Cloud API (OpenAI-compatible).
+    Recommended models: MiniMax-M2.7, MiniMax-M2.5, MiniMax-M2.5-highspeed (204K context).
+    """
+
+    def __init__(self, api_key=None, model_name=None):
+        self.api_key = api_key or os.getenv("MINIMAX_API_KEY", "")
+        self.model_name = model_name or "MiniMax-M2.7"
+        self.base_url = "https://api.minimax.io/v1"
+
+    def minimax_api_call(self, system_prompt: str, user_input: str, temperature: float, max_tokens: int):
+        """
+        Use MiniMax Chat API to perform text rewriting, parse <think>...</think> sections
+        for reasoning content, and return (thinking, result).
+        """
+        # MiniMax temperature range: [0.0, 1.0]
+        temperature = max(0.0, min(temperature, 1.0))
+
+        client = openai.OpenAI(base_url=self.base_url, api_key=self.api_key, timeout=600)
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_input},
+        ]
+
+        last_err = None
+
+        for i in range(10):
+            try:
+                response = client.chat.completions.create(
+                    model=self.model_name,
+                    messages=messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    stream=False,
+                )
+                content = response.choices[0].message.content
+                thinking = ""
+                result = content or ""
+                if content and "</think>" in content:
+                    head, tail = content.split("</think>", 1)
+                    thinking = head.replace("<think>", "").strip()
+                    result = tail.strip()
+                return thinking, result
+            except Exception as e:
+                last_err = e
+                if i < 9:
+                    time.sleep(2 ** i)
+                    continue
+                raise last_err
+
+    def run_single_recaption(self, system_prompt, input_prompt, temperature=0.1, max_tokens=4096):
+        thinking, result = self.minimax_api_call(system_prompt, input_prompt, temperature, max_tokens)
+        return result
+
+
 class QwenClient(object):
     def __init__(self, base_url=None, model_name=None):
         # Recommended model: Qwen3-235B-A22B-Thinking-2507

--- a/hyvideo/utils/rewrite/rewrite_utils.py
+++ b/hyvideo/utils/rewrite/rewrite_utils.py
@@ -15,20 +15,34 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 import os
-from hyvideo.utils.rewrite.clients import QwenClient, QwenVLClient
+from hyvideo.utils.rewrite.clients import QwenClient, QwenVLClient, MiniMaxClient
 from hyvideo.utils.rewrite.t2v_prompt import t2v_rewrite_system_prompt
 from hyvideo.utils.rewrite.i2v_prompt import i2v_rewrite_system_prompt
 
-def t2v_rewrite(user_prompt, rewrite_client=None):
+
+def _create_t2v_client():
+    """Create the appropriate T2V rewrite client based on REWRITE_PROVIDER env var."""
+    provider = os.getenv("REWRITE_PROVIDER", "").lower()
+    if provider == "minimax":
+        return MiniMaxClient(
+            api_key=os.getenv("MINIMAX_API_KEY"),
+            model_name=os.getenv("T2V_REWRITE_MODEL_NAME", "MiniMax-M2.7"),
+        )
+    # Default: QwenClient (vLLM-compatible)
     base_url = os.getenv("T2V_REWRITE_BASE_URL")
     model_name = os.getenv("T2V_REWRITE_MODEL_NAME")
     if not base_url or not model_name:
         raise EnvironmentError(
             "T2V_REWRITE_BASE_URL and T2V_REWRITE_MODEL_NAME must be set in the environment variables "
-            "when prompt rewriting is enabled. Please configure the rewrite service correctly."
+            "when prompt rewriting is enabled. Please configure the rewrite service correctly. "
+            "Alternatively, set REWRITE_PROVIDER=minimax and MINIMAX_API_KEY to use MiniMax Cloud API."
         )
+    return QwenClient(base_url, model_name)
+
+
+def t2v_rewrite(user_prompt, rewrite_client=None):
     if rewrite_client is None:
-        rewrite_client = QwenClient(base_url, model_name)
+        rewrite_client = _create_t2v_client()
     try:
         rewritten_prompt = rewrite_client.run_single_recaption(t2v_rewrite_system_prompt, user_prompt)
     except Exception as e:

--- a/tests/test_minimax_client.py
+++ b/tests/test_minimax_client.py
@@ -1,0 +1,450 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for MiniMaxClient integration."""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+# Add project root to path so we can import without installing
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+class TestMiniMaxClientInit(unittest.TestCase):
+    """Test MiniMaxClient initialization."""
+
+    def test_default_initialization(self):
+        from hyvideo.utils.rewrite.clients import MiniMaxClient
+
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}, clear=False):
+            client = MiniMaxClient()
+            self.assertEqual(client.api_key, "test-key")
+            self.assertEqual(client.model_name, "MiniMax-M2.7")
+            self.assertEqual(client.base_url, "https://api.minimax.io/v1")
+
+    def test_custom_initialization(self):
+        from hyvideo.utils.rewrite.clients import MiniMaxClient
+
+        client = MiniMaxClient(api_key="custom-key", model_name="MiniMax-M2.5")
+        self.assertEqual(client.api_key, "custom-key")
+        self.assertEqual(client.model_name, "MiniMax-M2.5")
+
+    def test_env_var_fallback(self):
+        from hyvideo.utils.rewrite.clients import MiniMaxClient
+
+        with patch.dict(os.environ, {}, clear=True):
+            client = MiniMaxClient()
+            self.assertEqual(client.api_key, "")
+            self.assertEqual(client.model_name, "MiniMax-M2.7")
+
+    def test_explicit_api_key_overrides_env(self):
+        from hyvideo.utils.rewrite.clients import MiniMaxClient
+
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "env-key"}, clear=False):
+            client = MiniMaxClient(api_key="explicit-key")
+            self.assertEqual(client.api_key, "explicit-key")
+
+
+class TestMiniMaxClientTemperatureClamping(unittest.TestCase):
+    """Test that temperature is clamped to [0.0, 1.0]."""
+
+    @patch("openai.OpenAI")
+    def test_temperature_clamped_high(self, mock_openai_cls):
+        from hyvideo.utils.rewrite.clients import MiniMaxClient
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "rewritten prompt"
+        mock_client.chat.completions.create.return_value = mock_response
+
+        client = MiniMaxClient(api_key="test")
+        client.minimax_api_call("system", "user", temperature=1.5, max_tokens=100)
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        self.assertEqual(call_kwargs["temperature"], 1.0)
+
+    @patch("openai.OpenAI")
+    def test_temperature_clamped_low(self, mock_openai_cls):
+        from hyvideo.utils.rewrite.clients import MiniMaxClient
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "rewritten prompt"
+        mock_client.chat.completions.create.return_value = mock_response
+
+        client = MiniMaxClient(api_key="test")
+        client.minimax_api_call("system", "user", temperature=-0.5, max_tokens=100)
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        self.assertEqual(call_kwargs["temperature"], 0.0)
+
+    @patch("openai.OpenAI")
+    def test_temperature_zero_accepted(self, mock_openai_cls):
+        from hyvideo.utils.rewrite.clients import MiniMaxClient
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "result"
+        mock_client.chat.completions.create.return_value = mock_response
+
+        client = MiniMaxClient(api_key="test")
+        client.minimax_api_call("system", "user", temperature=0.0, max_tokens=100)
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        self.assertEqual(call_kwargs["temperature"], 0.0)
+
+    @patch("openai.OpenAI")
+    def test_temperature_normal_passthrough(self, mock_openai_cls):
+        from hyvideo.utils.rewrite.clients import MiniMaxClient
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "result"
+        mock_client.chat.completions.create.return_value = mock_response
+
+        client = MiniMaxClient(api_key="test")
+        client.minimax_api_call("system", "user", temperature=0.7, max_tokens=100)
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        self.assertEqual(call_kwargs["temperature"], 0.7)
+
+
+class TestMiniMaxClientThinkTagStrip(unittest.TestCase):
+    """Test <think>...</think> parsing in MiniMaxClient."""
+
+    @patch("openai.OpenAI")
+    def test_think_tag_stripped(self, mock_openai_cls):
+        from hyvideo.utils.rewrite.clients import MiniMaxClient
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = (
+            "<think>I need to rewrite this prompt</think>A beautiful sunset scene"
+        )
+        mock_client.chat.completions.create.return_value = mock_response
+
+        client = MiniMaxClient(api_key="test")
+        thinking, result = client.minimax_api_call("system", "user", 0.1, 4096)
+
+        self.assertEqual(thinking, "I need to rewrite this prompt")
+        self.assertEqual(result, "A beautiful sunset scene")
+
+    @patch("openai.OpenAI")
+    def test_no_think_tag(self, mock_openai_cls):
+        from hyvideo.utils.rewrite.clients import MiniMaxClient
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "A beautiful sunset scene"
+        mock_client.chat.completions.create.return_value = mock_response
+
+        client = MiniMaxClient(api_key="test")
+        thinking, result = client.minimax_api_call("system", "user", 0.1, 4096)
+
+        self.assertEqual(thinking, "")
+        self.assertEqual(result, "A beautiful sunset scene")
+
+    @patch("openai.OpenAI")
+    def test_empty_content(self, mock_openai_cls):
+        from hyvideo.utils.rewrite.clients import MiniMaxClient
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = ""
+        mock_client.chat.completions.create.return_value = mock_response
+
+        client = MiniMaxClient(api_key="test")
+        thinking, result = client.minimax_api_call("system", "user", 0.1, 4096)
+
+        self.assertEqual(thinking, "")
+        self.assertEqual(result, "")
+
+
+class TestMiniMaxClientRunSingleRecaption(unittest.TestCase):
+    """Test run_single_recaption method."""
+
+    @patch("openai.OpenAI")
+    def test_returns_result_only(self, mock_openai_cls):
+        from hyvideo.utils.rewrite.clients import MiniMaxClient
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = (
+            "<think>reasoning</think>A cinematic scene of a cat"
+        )
+        mock_client.chat.completions.create.return_value = mock_response
+
+        client = MiniMaxClient(api_key="test")
+        result = client.run_single_recaption("system_prompt", "A cat video")
+
+        self.assertEqual(result, "A cinematic scene of a cat")
+
+    @patch("openai.OpenAI")
+    def test_default_temperature(self, mock_openai_cls):
+        from hyvideo.utils.rewrite.clients import MiniMaxClient
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "result"
+        mock_client.chat.completions.create.return_value = mock_response
+
+        client = MiniMaxClient(api_key="test")
+        client.run_single_recaption("system", "user")
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        self.assertEqual(call_kwargs["temperature"], 0.1)
+        self.assertEqual(call_kwargs["max_tokens"], 4096)
+
+
+class TestMiniMaxClientAPICall(unittest.TestCase):
+    """Test API call parameters."""
+
+    @patch("openai.OpenAI")
+    def test_correct_api_params(self, mock_openai_cls):
+        from hyvideo.utils.rewrite.clients import MiniMaxClient
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "result"
+        mock_client.chat.completions.create.return_value = mock_response
+
+        client = MiniMaxClient(api_key="test-key", model_name="MiniMax-M2.5-highspeed")
+        client.minimax_api_call("sys prompt", "user prompt", 0.3, 2048)
+
+        mock_openai_cls.assert_called_once_with(
+            base_url="https://api.minimax.io/v1",
+            api_key="test-key",
+            timeout=600,
+        )
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        self.assertEqual(call_kwargs["model"], "MiniMax-M2.5-highspeed")
+        self.assertEqual(call_kwargs["temperature"], 0.3)
+        self.assertEqual(call_kwargs["max_tokens"], 2048)
+        self.assertFalse(call_kwargs["stream"])
+
+    @patch("openai.OpenAI")
+    def test_messages_format(self, mock_openai_cls):
+        from hyvideo.utils.rewrite.clients import MiniMaxClient
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "result"
+        mock_client.chat.completions.create.return_value = mock_response
+
+        client = MiniMaxClient(api_key="test")
+        client.minimax_api_call("my system", "my user input", 0.1, 4096)
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        messages = call_kwargs["messages"]
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(messages[0]["role"], "system")
+        self.assertEqual(messages[0]["content"], "my system")
+        self.assertEqual(messages[1]["role"], "user")
+        self.assertEqual(messages[1]["content"], "my user input")
+
+    @patch("openai.OpenAI")
+    def test_retry_on_failure(self, mock_openai_cls):
+        from hyvideo.utils.rewrite.clients import MiniMaxClient
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "success"
+        mock_client.chat.completions.create.side_effect = [
+            Exception("rate limited"),
+            mock_response,
+        ]
+
+        client = MiniMaxClient(api_key="test")
+        with patch("time.sleep"):
+            thinking, result = client.minimax_api_call("sys", "user", 0.1, 100)
+
+        self.assertEqual(result, "success")
+        self.assertEqual(mock_client.chat.completions.create.call_count, 2)
+
+
+class TestRewriteUtilsProviderSelection(unittest.TestCase):
+    """Test _create_t2v_client provider selection."""
+
+    def test_minimax_provider_selected(self):
+        from hyvideo.utils.rewrite.rewrite_utils import _create_t2v_client
+        from hyvideo.utils.rewrite.clients import MiniMaxClient
+
+        with patch.dict(os.environ, {
+            "REWRITE_PROVIDER": "minimax",
+            "MINIMAX_API_KEY": "test-key",
+        }, clear=False):
+            client = _create_t2v_client()
+            self.assertIsInstance(client, MiniMaxClient)
+            self.assertEqual(client.api_key, "test-key")
+            self.assertEqual(client.model_name, "MiniMax-M2.7")
+
+    def test_minimax_provider_custom_model(self):
+        from hyvideo.utils.rewrite.rewrite_utils import _create_t2v_client
+        from hyvideo.utils.rewrite.clients import MiniMaxClient
+
+        with patch.dict(os.environ, {
+            "REWRITE_PROVIDER": "minimax",
+            "MINIMAX_API_KEY": "test-key",
+            "T2V_REWRITE_MODEL_NAME": "MiniMax-M2.5-highspeed",
+        }, clear=False):
+            client = _create_t2v_client()
+            self.assertIsInstance(client, MiniMaxClient)
+            self.assertEqual(client.model_name, "MiniMax-M2.5-highspeed")
+
+    def test_minimax_provider_case_insensitive(self):
+        from hyvideo.utils.rewrite.rewrite_utils import _create_t2v_client
+        from hyvideo.utils.rewrite.clients import MiniMaxClient
+
+        with patch.dict(os.environ, {
+            "REWRITE_PROVIDER": "MiniMax",
+            "MINIMAX_API_KEY": "test-key",
+        }, clear=False):
+            client = _create_t2v_client()
+            self.assertIsInstance(client, MiniMaxClient)
+
+    def test_default_provider_is_qwen(self):
+        from hyvideo.utils.rewrite.rewrite_utils import _create_t2v_client
+        from hyvideo.utils.rewrite.clients import QwenClient
+
+        with patch.dict(os.environ, {
+            "T2V_REWRITE_BASE_URL": "http://localhost:8000/v1",
+            "T2V_REWRITE_MODEL_NAME": "Qwen3-235B",
+        }, clear=False):
+            # Remove REWRITE_PROVIDER if present
+            os.environ.pop("REWRITE_PROVIDER", None)
+            client = _create_t2v_client()
+            self.assertIsInstance(client, QwenClient)
+
+    def test_default_provider_raises_without_env(self):
+        from hyvideo.utils.rewrite.rewrite_utils import _create_t2v_client
+
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(EnvironmentError) as ctx:
+                _create_t2v_client()
+            self.assertIn("MINIMAX_API_KEY", str(ctx.exception))
+
+    def test_empty_provider_falls_back_to_qwen(self):
+        from hyvideo.utils.rewrite.rewrite_utils import _create_t2v_client
+        from hyvideo.utils.rewrite.clients import QwenClient
+
+        with patch.dict(os.environ, {
+            "REWRITE_PROVIDER": "",
+            "T2V_REWRITE_BASE_URL": "http://localhost:8000/v1",
+            "T2V_REWRITE_MODEL_NAME": "Qwen3-235B",
+        }, clear=False):
+            client = _create_t2v_client()
+            self.assertIsInstance(client, QwenClient)
+
+
+class TestT2VRewriteWithMiniMax(unittest.TestCase):
+    """Test t2v_rewrite function with MiniMax provider."""
+
+    @patch("openai.OpenAI")
+    def test_t2v_rewrite_minimax(self, mock_openai_cls):
+        from hyvideo.utils.rewrite.rewrite_utils import t2v_rewrite
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "A cinematic wide shot of a girl"
+        mock_client.chat.completions.create.return_value = mock_response
+
+        with patch.dict(os.environ, {
+            "REWRITE_PROVIDER": "minimax",
+            "MINIMAX_API_KEY": "test-key",
+        }, clear=False):
+            result = t2v_rewrite("A girl")
+
+        self.assertEqual(result, "A cinematic wide shot of a girl")
+
+    def test_t2v_rewrite_with_explicit_client(self):
+        """Passing explicit rewrite_client should bypass provider selection."""
+        from hyvideo.utils.rewrite.rewrite_utils import t2v_rewrite
+
+        mock_client = MagicMock()
+        mock_client.run_single_recaption.return_value = "rewritten"
+
+        result = t2v_rewrite("test prompt", rewrite_client=mock_client)
+        self.assertEqual(result, "rewritten")
+        mock_client.run_single_recaption.assert_called_once()
+
+
+class TestMiniMaxIntegration(unittest.TestCase):
+    """Integration tests for MiniMax provider (require MINIMAX_API_KEY)."""
+
+    @unittest.skipUnless(
+        os.getenv("MINIMAX_API_KEY"),
+        "MINIMAX_API_KEY not set, skipping integration test",
+    )
+    def test_minimax_real_api_call(self):
+        from hyvideo.utils.rewrite.clients import MiniMaxClient
+
+        client = MiniMaxClient()
+        result = client.run_single_recaption(
+            "You are a helpful assistant. Reply briefly.",
+            "Say hello in one sentence.",
+            temperature=0.1,
+            max_tokens=50,
+        )
+        self.assertIsInstance(result, str)
+        self.assertTrue(len(result) > 0)
+
+    @unittest.skipUnless(
+        os.getenv("MINIMAX_API_KEY"),
+        "MINIMAX_API_KEY not set, skipping integration test",
+    )
+    def test_minimax_t2v_rewrite_integration(self):
+        from hyvideo.utils.rewrite.rewrite_utils import t2v_rewrite
+
+        with patch.dict(os.environ, {"REWRITE_PROVIDER": "minimax"}, clear=False):
+            result = t2v_rewrite("A cat sitting on a table")
+
+        self.assertIsInstance(result, str)
+        self.assertTrue(len(result) > 0)
+
+    @unittest.skipUnless(
+        os.getenv("MINIMAX_API_KEY"),
+        "MINIMAX_API_KEY not set, skipping integration test",
+    )
+    def test_minimax_m25_highspeed_model(self):
+        from hyvideo.utils.rewrite.clients import MiniMaxClient
+
+        client = MiniMaxClient(model_name="MiniMax-M2.5-highspeed")
+        result = client.run_single_recaption(
+            "You are a helpful assistant. Reply briefly.",
+            "Say hello in one sentence.",
+            temperature=0.1,
+            max_tokens=50,
+        )
+        self.assertIsInstance(result, str)
+        self.assertTrue(len(result) > 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add **MiniMax Cloud API** as an alternative prompt rewrite provider for text-to-video (T2V) generation
- Users can switch to MiniMax by setting `REWRITE_PROVIDER=minimax` and `MINIMAX_API_KEY`, eliminating the need to deploy a local vLLM server
- Default to **MiniMax-M3** (512K context, up to 128K output, image input support); also support `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives

## Changes

- **`hyvideo/utils/rewrite/clients.py`**: Add `MiniMaxClient` class with OpenAI-compatible API calls, temperature clamping to [0.0, 1.0], and `<think>` tag stripping; default model is `MiniMax-M3`
- **`hyvideo/utils/rewrite/rewrite_utils.py`**: Add `_create_t2v_client()` factory with `REWRITE_PROVIDER` env var for provider selection (defaults to existing Qwen/vLLM behavior); falls back to `MiniMax-M3` when `T2V_REWRITE_MODEL_NAME` is not set
- **`README.md`** / **`README_CN.md`**: Document MiniMax configuration with env vars and available models (M3 default, M2.7, M2.7-highspeed)
- **`tests/test_minimax_client.py`**: Unit + integration tests covering init, temperature clamping, think-tag parsing, provider selection (default `MiniMax-M3`), custom-model override, and end-to-end rewrite

## Usage

```bash
export REWRITE_PROVIDER=minimax
export MINIMAX_API_KEY="your_api_key"
# Optional: override model (default: MiniMax-M3)
# export T2V_REWRITE_MODEL_NAME="MiniMax-M2.7-highspeed"
```

## Available models

| Model | Notes |
|-------|-------|
| `MiniMax-M3` | Default. 512K context, up to 128K output, image input support |
| `MiniMax-M2.7` | Previous-generation model |
| `MiniMax-M2.7-highspeed` | Previous-generation low-latency variant |

## Test plan

- [x] Unit tests pass (mock-based, no API key required); default model asserted to be `MiniMax-M3`
- [x] Integration tests pass with real MiniMax API
- [x] Existing Qwen/vLLM provider behavior unchanged when `REWRITE_PROVIDER` is not set
- [ ] Verify prompt rewriting quality with actual video generation pipeline
