### PR TITLE
Fix --rewrite default value and reduce redundant tensor allocations in inference pipelines

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -314,7 +314,7 @@ def main():
              '--save_pre_sr_video false/0 to disable'
     )
     parser.add_argument(
-        '--rewrite', type=str_to_bool, nargs='?', const=True, default=False,
+        '--rewrite', type=str_to_bool, nargs='?', const=True, default=True,
         help='Enable prompt rewriting (default: true). '
              'Use --rewrite or --rewrite true/1 to enable, --rewrite false/0 to disable'
     )

--- a/hyvideo/pipelines/hunyuan_video_pipeline.py
+++ b/hyvideo/pipelines/hunyuan_video_pipeline.py
@@ -709,7 +709,7 @@ class HunyuanVideo_1_5_Pipeline(DiffusionPipeline):
             torch.Tensor or None: Vision states tensor or None if vision encoder is unavailable.
         """
         if reference_image is None:
-            vision_states = torch.zeros(latents.shape[0], self.config.vision_num_semantic_tokens, self.config.vision_states_dim).to(latents.device)
+            vision_states = torch.zeros(latents.shape[0], self.config.vision_num_semantic_tokens, self.config.vision_states_dim, device=latents.device, dtype=latents.dtype)
         else:
             reference_image = np.array(reference_image) if isinstance(reference_image, Image.Image) else reference_image
             if len(reference_image.shape) == 4:
@@ -753,11 +753,11 @@ class HunyuanVideo_1_5_Pipeline(DiffusionPipeline):
             latents_concat = cond_latents.repeat(1, 1, latents.shape[2], 1, 1)
             latents_concat[:, :, 1:, :, :] = 0.0
         else:
-            latents_concat = torch.zeros(latents.shape[0], latents.shape[1], latents.shape[2], latents.shape[3], latents.shape[4]).to(latents.device)
+            latents_concat = torch.zeros_like(latents)
         
-        mask_zeros = torch.zeros(latents.shape[0], 1, latents.shape[2], latents.shape[3], latents.shape[4])
-        mask_ones = torch.ones(latents.shape[0], 1, latents.shape[2], latents.shape[3], latents.shape[4])
-        mask_concat = merge_tensor_by_mask(mask_zeros.cpu(), mask_ones.cpu(), mask=multitask_mask.cpu(), dim=2).to(device=latents.device)
+        mask_zeros = torch.zeros(latents.shape[0], 1, latents.shape[2], latents.shape[3], latents.shape[4], device=latents.device)
+        mask_ones = torch.ones(latents.shape[0], 1, latents.shape[2], latents.shape[3], latents.shape[4], device=latents.device)
+        mask_concat = merge_tensor_by_mask(mask_zeros, mask_ones, mask=multitask_mask.to(device=latents.device), dim=2)
 
         cond_latents = torch.concat([latents_concat, mask_concat], dim=1)
         
@@ -1203,23 +1203,23 @@ class HunyuanVideo_1_5_Pipeline(DiffusionPipeline):
 
                 latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)
 
-                t_expand = t.repeat(latent_model_input.shape[0])
+                t_expand = t.expand(latent_model_input.shape[0])
                 if self.use_meanflow:
                     if i == len(timesteps) - 1:
                         timesteps_r = torch.tensor([0.0], device=self.execution_device)
                     else:
                         timesteps_r = timesteps[i + 1]
-                    timesteps_r = timesteps_r.repeat(latent_model_input.shape[0])
+                    timesteps_r = timesteps_r.expand(latent_model_input.shape[0])
                 else:
                     timesteps_r = None
 
                 guidance_expand = (
-                    torch.tensor(
-                        [embedded_guidance_scale] * latent_model_input.shape[0],
-                        dtype=torch.float32,
+                    torch.full(
+                        (latent_model_input.shape[0],),
+                        embedded_guidance_scale * 1000.0,
+                        dtype=self.target_dtype,
                         device=device,
-                    ).to(self.target_dtype)
-                    * 1000.0
+                    )
                     if embedded_guidance_scale is not None
                     else None
                 )

--- a/hyvideo/pipelines/hunyuan_video_sr_pipeline.py
+++ b/hyvideo/pipelines/hunyuan_video_sr_pipeline.py
@@ -156,7 +156,7 @@ class HunyuanVideo_1_5_SR_Pipeline(HunyuanVideo_1_5_Pipeline):
             torch.Tensor: Low-resolution conditional latent tensor.
         """
         b, _, f, h, w = lq_latents.shape
-        mask_ones = torch.ones(b, 1, f, h, w).to(lq_latents.device)
+        mask_ones = torch.ones(b, 1, f, h, w, device=lq_latents.device, dtype=lq_latents.dtype)
         cond_latents = torch.concat([lq_latents, mask_ones], dim=1)
         
         return cond_latents
@@ -379,7 +379,7 @@ class HunyuanVideo_1_5_SR_Pipeline(HunyuanVideo_1_5_Pipeline):
 
                 latent_model_input = self.scheduler.scale_model_input(latent_model_input, t)
 
-                t_expand = t.repeat(latent_model_input.shape[0])
+                t_expand = t.expand(latent_model_input.shape[0])
                 if not self.use_meanflow:
                     timesteps_r = None
                 else:
@@ -387,15 +387,15 @@ class HunyuanVideo_1_5_SR_Pipeline(HunyuanVideo_1_5_Pipeline):
                         timesteps_r = torch.tensor([0.0], device=self.execution_device)
                     else:
                         timesteps_r = timesteps[i + 1]
-                    timesteps_r = timesteps_r.repeat(latent_model_input.shape[0])
+                    timesteps_r = timesteps_r.expand(latent_model_input.shape[0])
 
                 guidance_expand = (
-                    torch.tensor(
-                        [embedded_guidance_scale] * latent_model_input.shape[0],
-                        dtype=torch.float32,
+                    torch.full(
+                        (latent_model_input.shape[0],),
+                        embedded_guidance_scale * 1000.0,
+                        dtype=self.target_dtype,
                         device=device,
-                    ).to(self.target_dtype)
-                    * 1000.0
+                    )
                     if embedded_guidance_scale is not None
                     else None
                 )


### PR DESCRIPTION
## Summary

### Bug Fix
- **Fix `--rewrite` default value**: The `--rewrite` argument in `generate.py` had `default=False`, contradicting the README documentation, the help text (`"default: true"`), and the original design intent (the initial commit's README referenced a `--disable_rewrite` flag, indicating rewrite was meant to be on by default). Additionally, the code logs a warning when rewrite is disabled ("may affect the quality"), further confirming that enabled is the intended default. Changed `default=False` → `default=True` to match documented behavior.

### Performance Optimizations
- Eliminate unnecessary CPU→GPU tensor transfers by specifying `device`/`dtype` at creation time instead of `torch.zeros(...).to(device)`
- Remove a GPU→CPU→GPU round-trip in `_prepare_cond_latents` where three tensors were moved to CPU for `merge_tensor_by_mask` then back to GPU — all operations can run directly on GPU
- Replace `t.repeat(n)` with zero-copy `t.expand(n)` for read-only timestep broadcasting in the denoising loop
- Replace `torch.tensor([val]*n, dtype=float32).to(target_dtype) * 1000.0` with a single `torch.full(...)` call, avoiding Python list construction, intermediate tensor allocation, and redundant dtype conversion

## Changed Files

- `generate.py` — fix `--rewrite` default
- `hyvideo/pipelines/hunyuan_video_pipeline.py` — tensor allocation optimizations
- `hyvideo/pipelines/hunyuan_video_sr_pipeline.py` — tensor allocation optimizations

## Optimization Details

| Before | After | Benefit |
|---|---|---|
| `torch.zeros(...).to(device)` | `torch.zeros(..., device=, dtype=)` / `zeros_like()` | Avoids temporary CPU allocation + PCIe transfer |
| 3× `.cpu()` + merge + `.to(device)` | All tensors on GPU, merge on GPU | Eliminates 4 device transfers (3 D2H + 1 H2D) |
| `t.repeat(n)` | `t.expand(n)` | O(1) zero-copy view vs O(n) allocation per denoising step |
| `torch.tensor([v]*n)` + `.to(dtype)` + `*1000` | `torch.full((n,), v*1000, dtype=)` | Eliminates Python list GC + 2 intermediate tensors |

## Test Plan

- [x] Verified all tensor optimizations with 20 unit tests covering shape/dtype/device equivalence, numerical correctness across float32/float16/bfloat16, 0-d tensor `expand` compatibility (PyTorch ≥ 2.2), and zero-copy memory sharing
